### PR TITLE
Update base image to alpine 3.20.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alpine:3.14.6
+FROM alpine:3.20.3
 
 MAINTAINER ops@lifen.fr
 


### PR DESCRIPTION
Since alpine version 3.14 does not receive security patches since 01 May 2023 I am opening this PR to update it to the latest version